### PR TITLE
Fix Validation fails on script tag attribute

### DIFF
--- a/plugins/random_text.rb
+++ b/plugins/random_text.rb
@@ -21,7 +21,7 @@ module Jekyll
     def render(context)
       rendered = <<-RANDJS
         <p id="#{@id}"></p>
-        <script text="javascript">
+        <script type="text/javascript">
           var request = new XMLHttpRequest();
           request.onload = function() {
             // get the file contents


### PR DESCRIPTION
PROBLEM

Various html validator reports `text` as invalid
script tag attribute.

CAUSE

Unknown.

SOLUTION

Correct the attribute as documented at:
- http://www.w3schools.com/tags/tag_script.asp
- http://www.w3schools.com/tags/att_script_type.asp

Fixes nirenjan/octopress-random-text#1
